### PR TITLE
Griders and basis_to_grid transformation modification.

### DIFF
--- a/n2v/grid/grider.py
+++ b/n2v/grid/grider.py
@@ -19,10 +19,6 @@ except:
 
 from .cubeprop import Cubeprop
 
-_default_grid = np.concatenate((np.linspace(-10,10,20, dtype=np.half)[:,None],
-                              np.linspace(-10,10,20, dtype=np.half)[:,None],
-                              np.linspace(-10,10,20, dtype=np.half)[:,None]), axis=1)
-
 class Grider(Cubeprop):
 
     def grid_to_blocks(self, grid, basis=None):
@@ -533,9 +529,6 @@ class Grider(Cubeprop):
             *Stores all grid quantities on self.grid. 
 
         """
-
-        if grid is None:
-            grid = _default_grid
 
         if show_progress == True:
             print("Generating Orbitals") 

--- a/n2v/grid/grider.py
+++ b/n2v/grid/grider.py
@@ -488,7 +488,7 @@ class Grider(Cubeprop):
         vext[:,1] = vext[:,0]
         esp[:,1] = esp[:,0]
         hartree = - 1.0 * (vext + esp)
-        v_fa = -1.0 / (self.nalpha + self.nbeta) * hartree
+        v_fa = (1 -1.0 / (self.nalpha + self.nbeta)) * hartree
 
         if cubic_grid is True:
             vext    = np.reshape(vext, (nshape, nshape, nshape, self.ref))
@@ -496,7 +496,7 @@ class Grider(Cubeprop):
             esp     = np.reshape(esp, (nshape, nshape, nshape, self.ref))
             v_fa    = np.reshape(v_fa, (nshape, nshape, nshape, self.ref))
 
-        psi4.set_num_threads(1)
+        psi4.set_num_threads(nthreads)
 
         return vext, hartree, v_fa, esp
 

--- a/n2v/grid/grider.py
+++ b/n2v/grid/grider.py
@@ -141,26 +141,20 @@ class Grider(Cubeprop):
         nblocks = vpot.nblocks()
         blocks = [vpot.get_block(i) for i in range(nblocks)]
         npoints = vpot.grid().npoints()
-        points_function = vpot.properties()[0]
 
-        x = np.empty((npoints))
-        y = np.empty((npoints))
-        z = np.empty((npoints))
-        w = np.empty((npoints))
+        dft_grid = np.empty(4, npoints)
 
         offset = 0
         for i_block in blocks:
             b_points = i_block.npoints()
             offset += b_points
 
-            x[offset - b_points : offset] = i_block.x().np
-            y[offset - b_points : offset] = i_block.x().np
-            z[offset - b_points : offset] = i_block.x().np
-            w[offset - b_points : offset] = i_block.x().np
+            dft_grid[0, offset - b_points : offset] = i_block.x().np
+            dft_grid[1, offset - b_points : offset] = i_block.y().np
+            dft_grid[2, offset - b_points : offset] = i_block.z().np
+            dft_grid[3, offset - b_points : offset] = i_block.w().np
 
-        dft_grid = [x,y,z,w]
-
-        return np.array(dft_grid)
+        return dft_grid
 
 
     #Quantities on grid

--- a/n2v/grid/grider.py
+++ b/n2v/grid/grider.py
@@ -31,8 +31,8 @@ class Grider(Cubeprop):
             grid to be distributed into blocks
             Size: (3, npoints) for homogeneous grid
                   (4, npoints) for inhomogenous grid to account for weights
-        basis: psi4.core.BasisSet. Default None
-            The basis set. If None, it will use target wfn.basisset().
+        basis: psi4.core.BasisSet; optional
+            The basis set. If not given, it will use target wfn.basisset().
 
         Returns
         -------
@@ -169,8 +169,8 @@ class Grider(Cubeprop):
             Vector/Matrix of quantity on ao basis. Shape: {(num_ao_basis, ), (num_ao_basis, num_ao_basis)}
         grid: np.ndarray Shape: (3, npoints) or (4, npoints)
             grid where density will be computed.
-        basis: psi4.core.BasisSet. Default None
-            The basis set. If None, it will use target wfn.basisset().
+        basis: psi4.core.BasisSet, optional
+            The basis set. If not given it will use target wfn.basisset().
         vpot: psi4.core.VBase
             Vpotential object with info about grid. 
             Provides DFT spherical grid. Only comes to play if no grid is given. 

--- a/n2v/grid/grider.py
+++ b/n2v/grid/grider.py
@@ -28,7 +28,7 @@ class Grider(Cubeprop):
         Parameters
         ----------
         grid: np.ndarray
-            grid to be distributed into blocks
+            Grid to be distributed into blocks
             Size: (3, npoints) for homogeneous grid
                   (4, npoints) for inhomogenous grid to account for weights
         basis: psi4.core.BasisSet; optional
@@ -43,7 +43,7 @@ class Grider(Cubeprop):
         points: psi4.core.{RKS, UKS}
             Points function to set matrices.
         """
-        assert (grid.shape[0] == 3) or (grid.shape[0] == 4), """grid does not have the correct dimensions. \n
+        assert (grid.shape[0] == 3) or (grid.shape[0] == 4), """Grid does not have the correct dimensions. \n
                                                               Array must be of size (3, npoints) or (4, npoints)"""
         if_w = grid.shape[0] == 4
 
@@ -157,7 +157,7 @@ class Grider(Cubeprop):
         return dft_grid
 
 
-    #Quantities on grid
+    #Quantities on Grid
     def on_grid_ao(self, coeff, grid=None, basis=None, vpot=None):
         """
         Generates a quantity on the grid given its ao representation.

--- a/n2v/grid/grider.py
+++ b/n2v/grid/grider.py
@@ -1,7 +1,7 @@
 """
 grider.py
 
-Generates grid for plotting 
+Generates grids for plotting 
 """
 
 import numpy as np
@@ -19,22 +19,24 @@ except:
 
 from .cubeprop import Cubeprop
 
-default_grid = np.concatenate((np.linspace(-10,10,20, dtype=np.half)[:,None],
+_default_grid = np.concatenate((np.linspace(-10,10,20, dtype=np.half)[:,None],
                               np.linspace(-10,10,20, dtype=np.half)[:,None],
                               np.linspace(-10,10,20, dtype=np.half)[:,None]), axis=1)
 
 class Grider(Cubeprop):
 
-    def grid_to_blocks(self, grid):
+    def grid_to_blocks(self, grids, basis=None):
         """
-        Generate list of blocks to allocate given grid
+        Generate list of blocks to allocate given grids
 
         Parameters
         ----------
-        grid: np.ndarray
-            Grid to be distributed into blocks
-            Size: (3, npoints) for homogeneous grid
-                  (4, npoints) for inhomogenous grid to account for weights
+        grids: np.ndarray
+            grids to be distributed into blocks
+            Size: (3, npoints) for homogeneous grids
+                  (4, npoints) for inhomogenous grids to account for weights
+        basis: psi4.core.BasisSet. Default None
+            The basis set. If None, it will use target wfn.basisset().
 
         Returns
         -------
@@ -45,25 +47,28 @@ class Grider(Cubeprop):
         points: psi4.core.{RKS, UKS}
             Points function to set matrices.
         """
-        assert (grid.shape[0] == 3) or (grid.shape[0] == 4), """Grid does not have the correct dimensions. \n
+        assert (grids.shape[0] == 3) or (grids.shape[0] == 4), """grids does not have the correct dimensions. \n
                                                               Array must be of size (3, npoints) or (4, npoints)"""
-        if_w = grid.shape[0] == 4
-             
+        if_w = grids.shape[0] == 4
+
+        if basis is None:
+            basis = self.basis
+
         epsilon    = psi4.core.get_global_option("CUBIC_BASIS_TOLERANCE")
-        extens     = psi4.core.BasisExtents(self.basis, epsilon)
+        extens     = psi4.core.BasisExtents(basis, epsilon)
         max_points = psi4.core.get_global_option("DFT_BLOCK_MAX_POINTS")        
-        npoints    = grid.shape[1]
+        npoints    = grids.shape[1]
         nblocks = int(np.floor(npoints/max_points))
         blocks = []
 
         #Run through full blocks
         idx = 0
         for nb in range(nblocks):
-            x = psi4.core.Vector.from_array(grid[0][idx : idx + max_points])
-            y = psi4.core.Vector.from_array(grid[1][idx : idx + max_points])
-            z = psi4.core.Vector.from_array(grid[2][idx : idx + max_points])
+            x = psi4.core.Vector.from_array(grids[0][idx : idx + max_points])
+            y = psi4.core.Vector.from_array(grids[1][idx : idx + max_points])
+            z = psi4.core.Vector.from_array(grids[2][idx : idx + max_points])
             if if_w:
-                w = psi4.core.Vector.from_array(grid[3][idx : idx + max_points])
+                w = psi4.core.Vector.from_array(grids[3][idx : idx + max_points])
             else:
                 w = psi4.core.Vector.from_array(np.zeros(max_points))  # When w is not necessary and not given
 
@@ -72,53 +77,53 @@ class Grider(Cubeprop):
 
         #Run through remaining points
         if idx < npoints:
-            x = psi4.core.Vector.from_array(grid[0][idx:])
-            y = psi4.core.Vector.from_array(grid[1][idx:])
-            z = psi4.core.Vector.from_array(grid[2][idx:])
+            x = psi4.core.Vector.from_array(grids[0][idx:])
+            y = psi4.core.Vector.from_array(grids[1][idx:])
+            z = psi4.core.Vector.from_array(grids[2][idx:])
             if if_w:
-                w = psi4.core.Vector.from_array(grid[3][idx:])
+                w = psi4.core.Vector.from_array(grids[3][idx:])
             else:
-                w = psi4.core.Vector.from_array(np.zeros_like(grid[2][idx:]))  # When w is not necessary and not given
+                w = psi4.core.Vector.from_array(np.zeros_like(grids[2][idx:]))  # When w is not necessary and not given
             blocks.append(psi4.core.BlockOPoints(x, y, z, w, extens))
 
         max_functions = 0 if 0 > len(blocks[-1].functions_local_to_global()) \
                                       else len(blocks[-1].functions_local_to_global())
 
         if self.ref == 1:
-            point_func = psi4.core.RKSFunctions(self.basis, max_points, max_functions)
+            point_func = psi4.core.RKSFunctions(basis, max_points, max_functions)
         else:
-            point_func = psi4.core.UKSFunctions(self.basis, max_points, max_functions)
+            point_func = psi4.core.UKSFunctions(basis, max_points, max_functions)
 
         return blocks, npoints, point_func
 
-    def generate_mesh(self, grid=default_grid):
+    def generate_grids(self, x, y, z):
         """
-        Genrates Mesh from 3 separate linear spaces
-        needed for cubic grid.
+        Genrates Mesh from 3 separate linear spaces and flatten,
+        needed for cubic grids.
 
         Parameters
         ----------
-        grid: np.ndarray
-            Grid needed to be turned into 3D mesh.
-        
+        grids: tuple of three np.ndarray
+            (x, y, z)
+
         Returns
         -------
-        out_grid: np.ndarray
-            Mesh grid as 3dimensional array
+        grids: np.ndarray
+            shape (3, len(x)*len(y)*len(z)).
         """
-
-        shape = (grid.shape[1], grid.shape[1], grid.shape[1])
-        X,Y,Z = np.meshgrid(grid[0],grid[1],grid[2])
+        # x,y,z, = grids
+        shape = (len(x), len(y), len(z))
+        X,Y,Z = np.meshgrid(x, y, z, indexing='ij')
         X = X.reshape((X.shape[0] * X.shape[1] * X.shape[2], 1))
         Y = Y.reshape((Y.shape[0] * Y.shape[1] * Y.shape[2], 1))
         Z = Z.reshape((Z.shape[0] * Z.shape[1] * Z.shape[2], 1))
-        grid = np.concatenate((X,Y,Z), axis=1).T
+        grids = np.concatenate((X,Y,Z), axis=1).T
 
-        return grid, shape
+        return grids, shape
 
     def generate_dft_grid(self, wfn):
         """
-        Extracts DFT spherical grid and weights from wfn object
+        Extracts DFT spherical grids and weights from wfn object
 
         Parameters
         ----------
@@ -128,7 +133,7 @@ class Grider(Cubeprop):
         -------
         dft_grid: list
             Numpy arrays corresponding to x,y,z, and w.
-            Shape: (4, npoints**3)
+            Shape: (4, npoints)
         
         """
 
@@ -139,7 +144,7 @@ class Grider(Cubeprop):
 
         nblocks = vpot.nblocks()
         blocks = [vpot.get_block(i) for i in range(nblocks)]
-        npoints = vpot.grid().npoints()
+        npoints = vpot.grids().npoints()
         points_function = vpot.properties()[0]
 
         x = np.empty((npoints))
@@ -159,55 +164,51 @@ class Grider(Cubeprop):
 
         dft_grid = [x,y,z,w]
 
-        return dft_grid
+        return np.array(dft_grid)
 
 
-    #Quantities on Grid
-    def on_grid_ao(self, coeff, grid=None, vpot=None, cubic_grid=False):
+    #Quantities on grids
+    def on_grid_ao(self, coeff, grids=None, basis=None, vpot=None):
         """
-        Generates a quantity on the grid given its ao representation
+        Generates a quantity on the grids given its ao representation.
+        *This is the most general function for basis to grid transformation.
 
         Parameters
         ----------
         coeff: np.ndarray
             Vector/Matrix of quantity on ao basis. Shape: {(num_ao_basis, ), (num_ao_basis, num_ao_basis)}
-        grid: np.ndarray. Shape ()
-            Grid where density will be computed.
-        cubic_grid: bool    
-            If False the resulting array won't be reshaped.
-            If True the resulting array will be reshaped as (npoints, nponits, npoints). 
-            Where npoints is the number of points for the grid in any one dimension.
+        grids: np.ndarray Shape: (3, npoints) or (4, npoints)
+            grids where density will be computed.
+        basis: psi4.core.BasisSet. Default None
+            The basis set. If None, it will use target wfn.basisset().
         vpot: psi4.core.VBase
-            Vpotential object with info about grid. 
-            Provides DFT spherical grid. Only comes to play if no grid is given. 
+            Vpotential object with info about grids. 
+            Provides DFT spherical grids. Only comes to play if no grids is given. 
 
         Returns
         -------
-        coeff_r: np.ndarray
-            Quantity expressed by the coefficient on the given grid 
-            Shape: (npoints) if cubic_grid is False
-                   (npoints, npoints, npoints) if cubic_grid is True
+        coeff_r: np.ndarray Shape: (npoints, )
+            Quantity expressed by the coefficient on the given grids 
+
 
         """
 
-        if cubic_grid is True and grid is not None:
-            nshape = grid.shape[1]
-            grid, shape = self.generate_mesh(grid)
-        elif cubic_grid is True and grid is None:
-            raise ValueError("'Cubic Grid' requires to explicitly specify grid")
 
-        if grid is not None and vpot is None:
-            blocks, npoints, points_function = self.grid_to_blocks(grid)
-        elif grid is None and vpot is not None:
+        if grids is not None:
+            if grids.shape[0] != 3 and grids.shape[0] != 4:
+                raise ValueError("The shape of grids should be (3, npoints) "
+                                 "or (4, npoints) but got (%i, %i)"%(grids.shape[0], grids.shape[1]))
+            blocks, npoints, points_function = self.grid_to_blocks(grids, basis=basis)
+        elif grids is None and vpot is not None:
             nblocks = vpot.nblocks()
             blocks = [vpot.get_block(i) for i in range(nblocks)]
-            npoints = vpot.grid().npoints()
+            npoints = vpot.grids().npoints()
             points_function = vpot.properties()[0]
         else:
-            blocks, npoints, points_function = self.grid_to_blocks(default_grid)
+            raise ValueError("A grids or a V_potential (DFT grids) must be given.")
 
         if self.ref == 1:
-            psi4_coeff = psi4.core.Vector.from_array(coeff[:,None])
+            psi4_coeff = psi4.core.Matrix.from_array(coeff[:,None])
             points_function.set_pointers(psi4_coeff)
         elif self.ref == 2:
             coeff_0 = coeff[:,None] if coeff.ndim == 1 else coeff.copy()
@@ -225,46 +226,34 @@ class Grider(Cubeprop):
 
             if coeff.ndim == 1:
                 l_mat = coeff[(lpos[:])]
-                coeff_r[offset - b_points : offset] = mat_r = contract('pm,m->p', phi, l_mat)
+                coeff_r[offset - b_points : offset] = contract('pm,m->p', phi, l_mat)
             elif coeff.ndim == 2: 
                 l_mat = coeff[(lpos[:, None], lpos)]
-                coeff_r[offset - b_points : offset] = mat_r = contract('pm,mn,pn->p', phi, l_mat, phi)
-
-        if cubic_grid is True:
-            coeff_r = np.reshape( coeff_r, (nshape, nshape, nshape))
+                coeff_r[offset - b_points : offset] = contract('pm,mn,pn->p', phi, l_mat, phi)
 
         return coeff_r
 
-    def on_grid_density(self, grid = None, 
+    def on_grid_density(self, grids=None,
                               Da=None, 
                               Db=None,
-                              cubic_grid = False,
                               vpot=None):
         """
-        Generates Density given grid
+        Generates Density given grids
 
         Parameters
         ----------
         Da, Db: np.ndarray
             Alpha, Beta densities. Shape: (num_ao_basis, num_ao_basis)
-        grid: np.ndarray
-            Grid where density will be computed
-        cubic_grid: bool    
-            If False the resulting array won't be reshaped.
-            If True the resulting array will be reshaped as (npoints, nponits, npoints). 
-            Where npoints is the number of points for the grid in any one dimension.
+        grids: np.ndarray Shape: (3, npoints) or (4, npoints)
+            grids where density will be computed.
         vpot: psi4.core.VBase
-            Vpotential object with info about grid.
-            Provides DFT spherical grid. Only comes to play if no grid is given. 
+            Vpotential object with info about grids.
+            Provides DFT spherical grids. Only comes to play if no grids is given. 
 
         Returns
         -------
-        density: np.ndarray
-            Density on the given grid. 
-            Shape: (npoints) if cubic_grid is False
-                   (npoints, npoints, npoints) if cubic_grid is True
-
-
+        density: np.ndarray Shape: (npoints, )
+            Density on the given grids. 
         """
 
         if Da is None and Db is None:
@@ -277,21 +266,18 @@ class Grider(Cubeprop):
         if self.ref == 2 and Db is None:
             raise ValueError("Db is required for an unrestricted system")
 
-        if cubic_grid is True and grid is not None:
-            nshape = grid.shape[1]
-            grid, shape = self.generate_mesh(grid)
-        elif cubic_grid is True and grid is None:
-            raise ValueError("'Cubic Grid' requires to explicitly specify grid")
-
-        if grid is not None and vpot is None:
-            blocks, npoints, points_function = self.grid_to_blocks(grid)
-        elif grid is None and vpot is not None:
+        if grids is not None:
+            if grids.shape[0] != 3 and grids.shape[0] != 4:
+                raise ValueError("The shape of grids should be (3, npoints) "
+                                 "or (4, npoints) but got (%i, %i)"%(grids.shape[0], grids.shape[1]))
+            blocks, npoints, points_function = self.grid_to_blocks(grids)
+        elif grids is None and vpot is not None:
             nblocks = vpot.nblocks()
             blocks = [vpot.get_block(i) for i in range(nblocks)]
-            npoints = vpot.grid().npoints()
+            npoints = vpot.grids().npoints()
             points_function = vpot.properties()[0]
         else:
-            blocks, npoints, points_function = self.grid_to_blocks(default_grid)
+            raise ValueError("A grids or a V_potential (DFT grids) must be given.")
 
         density   = np.empty((npoints, self.ref))
         if self.ref == 1:
@@ -311,35 +297,27 @@ class Grider(Cubeprop):
             if self.ref == 2:
                 density[offset - b_points : offset, 1] = 0.5 * rho_b.np[ :b_points]
 
-        if cubic_grid == True:
-            density = np.reshape(density, (nshape, nshape, nshape, self.ref))
-
         return density
 
-    def on_grid_orbitals(self, grid=None, Ca=None, Cb=None, vpot=None, cubic_grid=False):
+    def on_grid_orbitals(self, grids=None, Ca=None, Cb=None, vpot=None):
         """
-        Generates orbitals given grid
+        Generates orbitals given grids
 
         Parameters
         ----------
         Ca, Cb: np.ndarray
             Alpha, Beta Orbital Coefficient Matrix. Shape: (num_ao_basis, num_ao_basis)
-        grid: np.ndarray
-            Grid where density will be computed. Shape: {(npoints, 3), (npoints, 4)}
-        cubic_grid: bool    
-            If False the resulting array won't be reshaped.
-            If True the resulting array will be reshaped as (npoints, nponits, npoints). 
-            Where npoints is the number of points for the grid in any one dimension.
+        grids: np.ndarray Shape: (3, npoints) or (4, npoints)
+            grids where density will be computed
         vpot: psi4.core.VBase
-            Vpotential object with info about grid.
-            Provides DFT spherical grid. Only comes to play if no grid is given. 
+            Vpotential object with info about grids.
+            Provides DFT spherical grids. Only comes to play if no grids is given. 
 
         Returns
         -------
         orbitals: np.ndarray
-            Orbitals on the given grid of size . 
-            Shape: (nbasis, npoints, ref) if cubic_grid is False
-                   (nbasis, npoints, npoints, npoints, ref) if cubic_grid is True
+            Orbitals on the given grids of size . 
+            Shape: (nbasis, npoints, ref)
 
 
         """
@@ -354,21 +332,18 @@ class Grider(Cubeprop):
         if self.ref == 2 and Cb is None:
             raise ValueError("Db is required for an unrestricted system")
 
-        if cubic_grid is True and grid is not None:
-            nshape = grid.shape[1]
-            grid, shape = self.generate_mesh(grid)
-        elif cubic_grid is True and grid is None:
-            raise ValueError("'Cubic Grid' requires to explicitly specify grid")
-
-        if grid is not None and vpot is None:
-            blocks, npoints, points_function = self.grid_to_blocks(grid)
-        elif grid is None and vpot is not None:
+        if grids is not None:
+            if grids.shape[0] != 3 and grids.shape[0] != 4:
+                raise ValueError("The shape of grids should be (3, npoints) "
+                                 "or (4, npoints) but got (%i, %i)"%(grids.shape[0], grids.shape[1]))
+            blocks, npoints, points_function = self.grid_to_blocks(grids)
+        elif grids is None and vpot is not None:
             nblocks = vpot.nblocks()
             blocks = [vpot.get_block(i) for i in range(nblocks)]
-            npoints = vpot.grid().npoints()
+            npoints = vpot.grids().npoints()
             points_function = vpot.properties()[0]
         else:
-            blocks, npoints, points_function = self.grid_to_blocks(default_grid)
+            raise ValueError("A grids or a V_potential (DFT grids) must be given.")
 
         orbitals_r = [np.empty((npoints, self.ref)) for i_orb in range(self.nbf)]
 
@@ -385,7 +360,6 @@ class Grider(Cubeprop):
             points_function.compute_points(i_block)
             b_points = i_block.npoints()
             offset += b_points
-            w = np.array(i_block.w())
             lpos = np.array(i_block.functions_local_to_global())
             phi = np.array(points_function.basis_values()["PHI"])[:b_points, :lpos.shape[0]]
 
@@ -395,61 +369,43 @@ class Grider(Cubeprop):
                 orbitals_r[i_orb][offset - b_points : offset,0] = contract('m, pm -> p', Ca_local, phi)
                 orbitals_r[i_orb][offset - b_points : offset,1] = contract('m, pm -> p', Cb_local, phi)
 
-        if cubic_grid is True:
-            for i_orb in range(self.nbf):
-                orbitals_r[i_orb] = np.reshape( orbitals_r[i_orb], (nshape, nshape, nshape, self.ref))
-
         return orbitals_r
 
-    def on_grid_esp(self, wfn, grid=None, cubic_grid=False, vpot=None):
+    def on_grid_esp(self, grids=None, vpot=None):
 
         """
-        Generates EXTERNAL/ESP/HARTREE and Fermi Amaldi Potential on given grid
+        Generates EXTERNAL/ESP/HARTREE and Fermi Amaldi Potential on given grids
 
         Parameters
         ----------
-        wfn: psi4.core.{UKS, RKS, CCWavefunction,...}
-            Wavefunction Object 
-        grid: np.ndarray
-            Grid where density will be computed. Shape: {(npoints, 3), (npoints, 4)}
-        cubic_grid: bool    
-            If False the resulting array won't be reshaped.
-            If True the resulting array will be reshaped as (npoints, nponits, npoints). 
-            Where npoints is the number of points for the grid in any one dimension.
+        grids: np.ndarray Shape: (3, npoints) or (4, npoints)
+            grids where density will be computed.
         vpot: psi4.core.VBase
-            Vpotential object with info about grid.
-            Provides DFT spherical grid. Only comes to play if no grid is given. 
+            Vpotential object with info about grids.
+            Provides DFT spherical grids. Only comes to play if no grids is given. 
 
         Returns
         -------
         vext, hartree, esp, v_fa: np.ndarray
-            External, Hartree, ESP, and Fermi Amaldi potential on the given grid
-            Shape: (npoints) if cubic_grid is False
-                   (npoints, npoints, npoints) if cubic_grid is True
+            External, Hartree, ESP, and Fermi Amaldi potential on the given grids
+            Shape: (npoints, )
         """
 
         nthreads = psi4.get_num_threads()
         psi4.set_num_threads(1)
 
-        if cubic_grid is True and grid is not None:
-            nshape = grid.shape[1]
-            grid, shape = self.generate_mesh(grid)
-        elif cubic_grid is True and grid is None:
-            raise ValueError("'Cubic Grid' requires to explicitly specify grid")
-
-        if grid is not None and vpot is None:
-            blocks, npoints, points_function = self.grid_to_blocks(grid)
-        elif grid is None and vpot is not None:
+        if grids is not None:
+            blocks, npoints, points_function = self.grid_to_blocks(grids)
+        elif grids is None and vpot is not None:
             nblocks = vpot.nblocks()
             blocks = [vpot.get_block(i) for i in range(nblocks)]
-            npoints = vpot.grid().npoints()
-            points_function = vpot.properties()[0]
+            npoints = vpot.grids().npoints()
         else:
-            blocks, npoints, points_function = self.grid_to_blocks(default_grid)
+            raise ValueError("A grids or a V_potential (DFT grids) must be given.")
 
         #Initialize Arrays
-        vext = np.empty((npoints, self.ref))
-        esp  = np.empty((npoints, self.ref))
+        vext = np.zeros(npoints)
+        esp  = np.zeros(npoints)
 
         #Get Atomic Information
         mol_dict = self.mol.to_schema(dtype='psi4')
@@ -474,36 +430,27 @@ class Grider(Cubeprop):
 
                 #EXTERNAL
                 for atom in range(natoms):
-                    r =  np.sqrt( (x-rs[atom][0])**2 + (y-rs[atom][1])**2+ (z-rs[atom][2])**2)
-                    vext[offset - b_points : offset, 0] += -1.0 * zs[atom] / r
-                for i in range(len(vext[:,0])):
-                    if np.isinf(vext[i,0]) == True:
-                        vext[i,0] = 0.0
+                    r =  np.sqrt((x-rs[atom][0])**2 + (y-rs[atom][1])**2 + (z-rs[atom][2])**2)
+                    vext_temp = - 1.0 * zs[atom] / r
+                    vext_temp[np.isinf(vext_temp)] = 0.0
+                    vext[offset - b_points : offset] += vext_temp
                 #ESP
                 xyz = np.concatenate((x[:,None],y[:,None],z[:,None]), axis=1)
                 grid_block = psi4.core.Matrix.from_array(xyz)
-                esp[offset - b_points : offset, 0] = esp_wfn.compute_esp_over_grid_in_memory(grid_block).np
+                esp[offset - b_points : offset] = esp_wfn.compute_esp_over_grid_in_memory(grid_block).np
 
         #Hartree
-        vext[:,1] = vext[:,0]
-        esp[:,1] = esp[:,0]
         hartree = - 1.0 * (vext + esp)
-        v_fa = (1 -1.0 / (self.nalpha + self.nbeta)) * hartree
-
-        if cubic_grid is True:
-            vext    = np.reshape(vext, (nshape, nshape, nshape, self.ref))
-            hartree = np.reshape(hartree, (nshape, nshape, nshape, self.ref))
-            esp     = np.reshape(esp, (nshape, nshape, nshape, self.ref))
-            v_fa    = np.reshape(v_fa, (nshape, nshape, nshape, self.ref))
+        v_fa = (1 - 1.0 / (self.nalpha + self.nbeta)) * hartree
 
         psi4.set_num_threads(nthreads)
 
         return vext, hartree, v_fa, esp
 
-    def on_grid_vxc(self, func_id=1, grid=None, Da=None, Db=None,
-                          cubic_grid=False, vpot=None):
+    def on_grid_vxc(self, func_id=1, grids=None, Da=None, Db=None,
+                          vpot=None):
         """
-        Generates Vxc given grid
+        Generates Vxc given grids
 
         Parameters
         ----------
@@ -512,40 +459,29 @@ class Grider(Cubeprop):
         func_id: int
             Functional ID associated with Density Functional Approximationl.
             Full list of functionals: https://www.tddft.org/programs/libxc/functionals/
-        grid: np.ndarray
-            Grid where density will be computed. Shape: {(npoints, 3), (npoints, 4)}
-        cubic_grid: bool    
-            If False the resulting array won't be reshaped.
-            If True the resulting array will be reshaped as (npoints, nponits, npoints). 
-            Where npoints is the number of points for the grid in any one dimension.
+        grids: np.ndarray Shape: (3, npoints) or (4, npoints)
+            grids where density will be computed.
         vpot: psi4.core.VBase
-            Vpotential object with info about grid.
-            Provides DFT spherical grid. Only comes to play if no grid is given. 
+            Vpotential object with info about grids.
+            Provides DFT spherical grids. Only comes to play if no grids is given. 
 
         Returns
         -------
         VXC: np.ndarray
-            Exchange correlation potential on the given grid
-            Shape: (npoints) if cubic_grid is False
-                   (npoints, npoints, npoints) if cubic_grid is True
+            Exchange correlation potential on the given grids
+            Shape: (npoints, )
 
         """
 
         if func_id != 1:
-            raise ValueError("Only LDA fucntionals are supported on the grid")
-
-        if cubic_grid is True and grid is not None:
-            nshape = grid.shape[1]
-            grid, shape = self.generate_mesh(grid)
-        elif cubic_grid is True and grid is None:
-            raise ValueError("'Cubic Grid' requires to explicitly specify grid")
+            raise ValueError("Only LDA fucntionals are supported on the grids")
 
         if  Da is None and Db is None and vpot is None:
-            density = self.on_grid_density(grid=grid)
+            density = self.on_grid_density(grids=grids)
         elif Da is not None and Db is None and vpot is None:
-            density = self.on_grid_density(grid=grid, Da=Da)
+            density = self.on_grid_density(grids=grids, Da=Da)
         elif Da is not None and Db is not None and vpot is None:
-            density = self.on_grid_density(grid=grid, Da=Da, Db=Db)
+            density = self.on_grid_density(grids=grids, Da=Da, Db=Db)
         ###
         elif Da is None and Db is None and vpot is not None:
             density = self.on_grid_density(vpot=vpot)        
@@ -554,15 +490,14 @@ class Grider(Cubeprop):
         elif Da is not None and Db is not None and vpot is not None:
             density = self.on_grid_density(Da=Da, Db=Db, vpot=vpot)
 
-        if grid is not None and vpot is None:
-            blocks, npoints, points_function = self.grid_to_blocks(grid)
-        elif grid is None and vpot is not None:
+        if grids is not None:
+            blocks, npoints, points_function = self.grid_to_blocks(grids)
+        elif grids is None and vpot is not None:
             nblocks = vpot.nblocks()
             blocks = [vpot.get_block(i) for i in range(nblocks)]
-            npoints = vpot.grid().npoints()
-            points_function = vpot.properties()[0]
+            npoints = vpot.grids().npoints()
         else:
-            blocks, npoints, points_function = self.grid_to_blocks(default_grid)
+            raise ValueError("A grids or a V_potential (DFT grids) must be given.")
 
         vxc = np.empty((npoints, self.ref))
         ingredients = {}
@@ -579,72 +514,54 @@ class Grider(Cubeprop):
             xc_dictionary = functional.compute(ingredients)
             vxc[offset - b_points : offset, :] = np.squeeze(xc_dictionary['vrho'])
 
-        if cubic_grid is True:
-            vxc = np.reshape(vxc, (nshape, nshape, nshape, self.ref))
-
         return vxc
 
-    def on_grid_all(self, grid=None, cubic_grid=False, show_progress=False):
+    def on_grid_all(self, grids=None, show_progress=False):
         """
         Calls *all* 'on_grid_x' functions using densities and coefficients stored in Inverter object. 
 
         Parameters
         ----------
-        grid: np.ndarray
-            Grid where density will be computed. Shape: {(npoints, 3), (npoints, 4)}
-        cubic_grid: bool    
-            If False the resulting array won't be reshaped.
-            If True the resulting array will be reshaped as (npoints, nponits, npoints). 
-            Where npoints is the number of points for the grid in any one dimension.
+        grids: np.ndarray Shape: (3, npoints) or (4, npoints)
+            grids where density will be computed.
         show_progress: bool 
             If True. Prints confirmation of each component generated. 
 
         Returns
         -------
         None:
-            *Stores all grid quantities on self.grid. 
+            *Stores all grids quantities on self.grid. 
 
         """
 
-        if grid is None:
-            grid = default_grid
-
-        npoints = grid.shape[1]
+        if grids is None:
+            grids = _default_grid
 
         if show_progress == True:
             print("Generating Orbitals") 
-        density = self.on_grid_density(grid=grid, cubic_grid=cubic_grid)
+        density = self.on_grid_density(grids=grids)
         if show_progress == True:
             print("Generating Orbitals") 
-        orbitals = self.on_grid_orbitals(grid=grid, cubic_grid=cubic_grid)
+        orbitals = self.on_grid_orbitals(grids=grids)
         if show_progress is True:
             print("Generating Ext/Hartree/ESP") 
-        vext, hartree, esp, v_fa = self.on_grid_esp(wfn=self.wfn, grid=grid, cubic_grid=cubic_grid)
+        vext, hartree, esp, v_fa = self.on_grid_esp(wfn=self.wfn, grids=grids)
         if show_progress is True:
             print("Generating Vxc") 
-        vxc = self.on_grid_vxc(grid=grid, cubic_grid=cubic_grid)
+        vxc = self.on_grid_vxc(grids=grids)
 
-        if cubic_grid is False:
-            self.grid.density = density
-            self.grid.orbitals = orbitals
-            self.grid.vext = vext
-            self.grid.hartree = hartree
-            self.grid.esp = esp
-            self.grid.v_fa = v_fa
-            self.grid.vxc = vxc
-        elif cubic_grid is True:
-            self.cubic_grid.density = np.reshape(density, (npoints, npoints, npoints, self.ref))
-            self.cubic_grid.orbitals = np.reshape(orbitals, (self.nbf, npoints, npoints, npoints, self.ref))
-            self.cubic_grid.vext = np.reshape(vext, (npoints, npoints, npoints, self.ref))
-            self.cubic_grid.hartree = np.reshape(hartree, (npoints, npoints, npoints, self.ref))
-            self.cubic_grid.esp = np.reshape(esp, (npoints, npoints, npoints, self.ref))
-            self.cubic_grid.v_fa = np.reshape(v_fa, (npoints, npoints, npoints, self.ref))
-            self.cubic_grid.vxc = np.reshape(vxc, (npoints, npoints, npoints, self.ref))
+        self.grid.density = density
+        self.grid.orbitals = orbitals
+        self.grid.vext = vext
+        self.grid.hartree = hartree
+        self.grid.esp = esp
+        self.grid.v_fa = v_fa
+        self.grid.vxc = vxc
 
         return
 
     def dft_grid_to_fock(self, value, Vpot):
-        """For value on DFT spherical grid, Fock matrix is returned.
+        """For value on DFT spherical grids, Fock matrix is returned.
         VFock_ij = \int dx \phi_i(x) \phi_j(x) value(x)
         
         Parameters:
@@ -652,8 +569,8 @@ class Grider(Cubeprop):
         value: np.ndarray of shape (npoint, ).
 
         Vpot:psi4.core.VBase
-            Vpotential object with info about grid.
-            Provides DFT spherical grid. Only comes to play if no grid is given.
+            Vpotential object with info about grids.
+            Provides DFT spherical grids. Only comes to play if no grids is given.
         
         Returns:
         ---------
@@ -672,7 +589,7 @@ class Grider(Cubeprop):
             npoints = block.npoints()
             lpos = np.array(block.functions_local_to_global())
 
-            # Obtain the grid weight
+            # Obtain the grids weight
             w = np.array(block.w())
 
             # Compute phi!

--- a/n2v/inverter.py
+++ b/n2v/inverter.py
@@ -244,11 +244,9 @@ class Inverter(WuYang, ZMP, MRKS, Grider):
             self.va += v_fa
             self.vb += v_fa
 
-        if "svwn" in guide_potential_components or "pbe" in guide_potential_components:
+        if "svwn" in guide_potential_components:
             if "svwn" in guide_potential_components:
                 _, wfn_0 = psi4.energy( "svwn"+"/"+self.basis_str, molecule=self.mol , return_wfn = True)
-            else:
-                _, wfn_0 = psi4.energy( "pbe"+"/"+self.basis_str, molecule=self.mol , return_wfn = True)
 
             if self.ref == 1:
                 ntarget = psi4.core.Matrix.from_array( [ self.nt[0] + self.nt[1] ] )

--- a/n2v/inverter.py
+++ b/n2v/inverter.py
@@ -204,7 +204,7 @@ class Inverter(WuYang, ZMP, MRKS, Grider):
 
     #------------->  Inversion:
 
-    def invert(self, method="wuyang", 
+    def invert(self, method,
                      opt_method='trust-krylov', 
                      potential_components = ["fermi_amaldi", "svwn"], 
                      opt_max_iter = 50,
@@ -239,7 +239,7 @@ class Inverter(WuYang, ZMP, MRKS, Grider):
         self.Hartree_a, self.Hartree_b = J[0], J[1]
 
         if "fermi_amaldi" in potential_components:
-            v_fa = (-1/N) * (J[0] + J[1])
+            v_fa = (N-1/N) * (J[0] + J[1])
 
             self.va += v_fa
             self.vb += v_fa

--- a/n2v/inverter.py
+++ b/n2v/inverter.py
@@ -68,12 +68,16 @@ class Inverter(WuYang, ZMP, MRKS, Grider):
         The three ao overlap matrix (ao, ao, pbs)
     jk  : psi4.core.JK
         Psi4 jk object. Built if wfn has no jk, otherwise use wfn.jk
+
     T   : np.ndarray
         kinetic matrix on ao
     V   : np.ndarray
         external potential matrix on ao
     T_pbs: np.ndarray
         kinetic matrix on pbs. Useful for regularization.
+
+    va, vb: np.ndarray of shape (nbasis, nbasis)
+        guide potential component of Fock matrix.
     Methods:
     --------
 
@@ -205,12 +209,12 @@ class Inverter(WuYang, ZMP, MRKS, Grider):
                      potential_components = ["fermi_amaldi", "svwn"], 
                      opt_max_iter = 50,
                      opt_tol      = 1e-5,
-                     reg=0.0):
+                     reg=None):
         """
         Handler to all available inversion methods
         """
 
-        self.reg = reg
+        self.lambda_reg = reg
         self.generate_components(potential_components)
 
         if method.lower() == "wuyang":

--- a/n2v/methods/wuyang.py
+++ b/n2v/methods/wuyang.py
@@ -17,15 +17,14 @@ class WuYang():
     lambda_rgl: {None, float}. If float, lambda-regularization is added with lambda=lambda_rgl.
     """
 
-    lambda_rgl = None  # If add lambda regularization
-
+    regul_norm = None  # Regularization norm: ||v||^2
 
     def wuyang(self, opt_method, opt_max_iter, opt_tol):
         """
         Calls scipy minimizer to minimize lagrangian. 
         """
 
-        if opt_method == 'bfgs':
+        if opt_method == 'bfgs' or opt_method == 'l-bfgs-b':
             opt_results = minimize( fun = self.lagrangian,
                                     x0  = self.v0, 
                                     jac = self.gradient,
@@ -96,14 +95,21 @@ class WuYang():
             optimizing +=   np.sum(v[self.npbs:] * self.grad_b)
             L = kinetic + potential + optimizing
 
+        # Add lambda-regularization
+        if self.lambda_reg is not None:
+            T = self.T_pbs
+            if self.ref == 1:
+                norm = 2 * (v[self.npbs:] @ T @ v[self.npbs:])
+            else:
+                norm = (v[self.npbs:] @ T @ v[self.npbs:]) + (v[:self.npbs] @ T @ v[:self.npbs])
+
+            L += norm * self.lambda_reg
+            self.regul_norm = norm
+
         if False:
             print(f"Kinetic: {kinetic:6.4f} | Potential: {np.abs(potential):6.4e} | From Optimization: {np.abs(optimizing):6.4e}")
 
-        reg = 0.0
-        if self.reg > 0:
-            pass
-
-        return - L - reg
+        return - L
 
     def gradient(self, v):
         """
@@ -118,6 +124,16 @@ class WuYang():
             self.grad   = self.grad_a
         else:
             self.grad   = np.concatenate(( self.grad_a, self.grad_b ))
+
+        if self.lambda_reg is not None:
+            T = self.T_pbs
+            if self.ref == 1:
+                rgl_vector = 4 * self.lambda_reg*np.dot(T, v[:self.npbs])
+                self.grad[:self.npbs] += rgl_vector
+                self.grad[self.npbs:] += rgl_vector
+            else:
+                self.grad[:self.npbs] += 2 * self.lambda_reg*np.dot(T, v[:self.npbs])
+                self.grad[self.npbs:] += 2 * self.lambda_reg*np.dot(T, v[self.npbs:])
 
         return -self.grad
 
@@ -136,20 +152,135 @@ class WuYang():
         Ha = 2 * contract('iau,iat,ia->ut', C3a, C3a, eigs_diff_a**-1)
 
         if self. ref == 1:
+            if self.lambda_reg is not None:
+                Ha += 4 * self.T_pbs
             Hs = Ha
 
         else:
             eigs_diff_b = self.eigvecs_b[:nb, None] - self.eigvecs_b[None, nb:]
             C3b = contract('mi,va,mvt->iat', self.Cb[:,:nb], self.Cb[:,nb:], self.S3)
             Hb = 2 * contract('iau,iat,ia->ut', C3b, C3b, eigs_diff_b**-1)
-            Hs = np.block( 
+            if self.lambda_reg is not None:
+                Hb += 4 * self.T_pbs
+            Hs = np.block(
                             [[Ha,                               np.zeros((self.npbs, self.npbs))],
                             [np.zeros((self.npbs, self.npbs)), Hb                              ]]
                         )
 
-        if self.reg > 0.0:
-            pass
-
         return - Hs
 
-    #TODO Regularization
+    def find_regularization_constant(self, opt_method, potential_components, tol=None, opt=None, lambda_list=None):
+        """
+        Finding regularization constant lambda.
+
+        Note: it is recommend to set a specific convergence criteria by opt or tol,
+                in order to control the same convergence
+                for different lambda value.
+
+        After the calculation is done, one can plot the returns to select a good lambda.
+
+        Parameters:
+        -----------
+        opt_method: string
+            opt_methods available in scipy.optimize.minimize
+
+        potential_components: the components for guide potential v0.
+
+        tol: float
+            Tolerance for termination. See scipy.optimize.minimize for details.
+
+        opt: default None, or dictionary
+            if None:
+
+            if given:
+                scipy.optimize.minimize(method=opt_method, options=opt)
+
+        lambda_list: default None, or np.ndarray
+            A array of lambda to search. If None, then it will be 10 ** np.linspace(-1, -7, 7).
+
+        Returns:
+        --------
+        lambda_list: np.ndarray
+            A array of lambda searched.
+
+        P_list: np.ndarray
+            The value defined by [Bulat, Heaton-Burgess, Cohen, Yang 2007] eqn (21).
+            Corresponding to lambda in lambda_list.
+
+        Ts_list: np.ndarray
+            The Ts value for each lambda.
+
+
+        """
+
+        Ts_list = []
+        L_list = []
+        v_norm_list = []
+
+
+        if lambda_list is None:
+            lambda_list = 10 ** np.linspace(-1, -7, 7)
+
+        if opt is None:
+            opt = {
+                "maxiter": 100,
+                "disp": False
+            }
+
+        self.generate_components(potential_components)
+
+        # Initial calculation with no regularization
+        if opt_method == 'bfgs' or opt_method == 'l-bfgs-b':
+            initial_result = minimize(fun=self.lagrangian,
+                                   x0=self.v0,
+                                   jac=self.gradient,
+                                   method=opt_method,
+                                   tol=tol,
+                                   options=opt
+                                   )
+        else:
+            initial_result = minimize(fun=self.lagrangian,
+                                   x0=self.v0,
+                                   jac=self.gradient,
+                                   hess=self.hessian,
+                                   method=opt_method,
+                                   tol=tol,
+                                   options=opt
+                                   )
+        if initial_result.success == False:
+            raise ValueError("Optimization was unsucessful, try a different intitial guess")
+        else:
+            L0 = -initial_result.f
+            initial_v0 = initial_result.x  # This is used as the initial guess for with regularization calculation.
+        for reg in lambda_list:
+            self.lambda_reg = reg
+
+            if opt_method == 'bfgs' or opt_method == 'l-bfgs-b':
+                opt_results = minimize(fun=self.lagrangian,
+                                       x0=initial_v0,
+                                       jac=self.gradient,
+                                       method=opt_method,
+                                       tol=tol,
+                                       options=opt
+                                       )
+
+            else:
+                opt_results = minimize(fun=self.lagrangian,
+                                       x0=initial_v0,
+                                       jac=self.gradient,
+                                       hess=self.hessian,
+                                       method=opt_method,
+                                       tol=tol,
+                                       options=opt
+                                       )
+
+            if opt_results.success == False:
+                raise ValueError("Optimization was unsucessful, try a different intitial guess")
+
+            Ts_list.append(np.sum(self.T * (self.Da + self.Db)))
+            v_norm_list.append(self.regul_norm)
+            L_list.append(-opt_results.fun - self.lambda_reg * self.regul_norm)
+
+        P_list = lambda_list * np.array(v_norm_list) / (L0 - np.array(L_list))
+
+        return lambda_list, P_list, np.array(Ts_list)


### PR DESCRIPTION
I replaced "grid" to "grids" to make it consistent (some functions use grids but other grid) so please ignore those parts.

I regularized the interface to each function: they will all ask for a input "grids: np.ndarray of shape (3, npoints) or (4, npoints) which could be given by the user of generate by generate_grid function. I modified some bugs including the indexing="ij" instead of "xy" in generate_grid.