### PR TITLE
Basis set Correction

### DIFF
--- a/n2v/grid/basis_set_artifact_correction.py
+++ b/n2v/grid/basis_set_artifact_correction.py
@@ -5,7 +5,6 @@ Basis Set Artifact Correction.
 import numpy as np
 from warnings import warn
 import psi4
-np.seterr(divide='ignore', invalid='ignore')
 
 def invert_kohn_sham_equations(self, wfn, grid):
     """

--- a/n2v/grid/basis_set_artifact_correction.py
+++ b/n2v/grid/basis_set_artifact_correction.py
@@ -1,0 +1,173 @@
+"""
+Basis Set Artifact Correction. 
+"""
+
+import numpy as np
+from warnings import warn
+import psi4
+np.seterr(divide='ignore', invalid='ignore')
+
+def invert_kohn_sham_equations(self, wfn, grid):
+    """
+    Given a set of canonical kohn-sham orbitals and energies,
+    construct vxc by inverting the Kohn-Sham Equations.
+    Removal of Basis-Set Artifacts in Kohn–Sham Potentials Recovered from Electron Densities
+    Gaiduk + Ryabinkin + Staroverov
+    https://pubs.acs.org/doi/abs/10.1021/ct4004146
+
+    Parameters:
+    -----------
+    wfn: psi4.core.Wavefunction
+        Wavefunction from target calculation. 
+        Must be obtained from same basis set if future correction will be applied
+    grid: np.ndarray. Shape: (3xnpoints)
+        Grid used to compute correction. 
+        If None, dft grid is used. 
+
+    Returns:
+    --------
+    vxc_inverted: np.ndarray
+        Vxc obtained from inverting kohn sham equations. 
+        Equation (3)
+    vxc_lda: np.ndarray
+        LDA potential from forward calculation. 
+    osc_profile: np.ndarray
+        Oscillatory profile that corrects inverted potentials. 
+        Equation (5)
+    """
+
+    if wfn.basisset().name() != self.basis_str:
+        warn("""Basis set from calculation is different from Inverter object. \n
+                Addition of correction won't fix basis set artifacts.""")
+                                
+    #Build components on grid:
+    if grid is not None:
+        #Use user-defined grid
+        orb       = self.on_grid_orbitals(Ca=wfn.Ca().np, Cb=wfn.Cb().np, grid=grid)
+        lap       = self.on_grid_lap_phi(Ca=wfn.Ca().np, Cb=wfn.Cb().np, grid=grid)
+        vex, vha  = self.on_grid_esp(Da=wfn.Da().np, Db=wfn.Db().np, grid=grid)[:2]
+        den       = self.on_grid_density(Da=wfn.Da().np, Db=wfn.Db().np, grid=grid)
+        eig_a = wfn.epsilon_a_subset("AO", "ALL").np
+        eig_b = wfn.epsilon_b_subset("AO", "ALL").np
+        
+    else:
+        #Use DFT grid
+        vpot = wfn.V_potential()
+        orb       = self.on_grid_orbitals(Ca=wfn.Ca().np, Cb=wfn.Cb().np, vpot=vpot)
+        lap       = self.on_grid_lap_phi(Ca=wfn.Ca().np, Cb=wfn.Cb().np, vpot=vpot)
+        vex, vha  = self.on_grid_esp(Da=wfn.Da().np, Db=wfn.Db().np, vpot=vpot)[:2]
+        den       = self.on_grid_density(Da=wfn.Da().np, Db=wfn.Db().np, vpot=vpot)
+        eig_a = wfn.epsilon_a_subset("AO", "ALL").np
+
+    #Build Reversed LDA from orbitals and density
+    kinetic = np.zeros_like(den)
+    propios = np.zeros_like(den) 
+
+    #Build v_eff. equation (2) for restricted and unrestricted
+    if self.ref == 1:
+        for i in range(wfn.nalpha()):
+            #Alpha orbitals
+            kinetic += 2.0 * (0.5 * orb[i] * lap[i])
+            propios += 2.0 * eig_a[i] * np.abs(orb[i])**2 
+        
+        with np.errstate(divide='ignore', invalid='ignore'):
+            veff = (kinetic + propios) / den
+        vxc_inverted = veff - vha - vex
+        
+    elif self.ref== 2:
+        for i in range(wfn.nalpha()):
+            #Alpha orbitals
+            kinetic[:,0] += (0.5 * orb[i][:,0] * lap[i][:,0])
+            propios[:,0] += eig_a[i] * np.abs(orb[i][:,0])**2 
+        for i in range(wfn.nbeta()):
+            #Beta orbitals
+            kinetic[:,1] += (0.5 * orb[i][:,1] * lap[i][:,1])
+            propios[:,1] += eig_b[i] * np.abs(orb[i][:,1])**2 
+
+        with np.errstate(divide='ignore', invalid='ignore'):
+            veff = (kinetic + propios) / den
+        vxc_inverted = veff - np.repeat(vha[:,None], 2, axis=1) - np.repeat(vex[:,None], 2, axis=1)
+
+    return vxc_inverted
+
+def basis_set_correction(self, grid):
+    """
+    Obtains basis set correction for inverted potentials as in:
+    Removal of Basis-Set Artifacts in Kohn–Sham Potentials Recovered from Electron Densities
+    Gaiduk + Ryabinkin + Staroverov
+    https://pubs.acs.org/doi/abs/10.1021/ct4004146
+
+    Parameters:
+    -----------
+    grid: np.ndarray. Shape: (3xnpoints)
+        Grid used to compute correction. 
+        If None, dft grid is used. 
+
+    Returns:
+    --------
+    vxc_inverted: np.ndarray
+        Vxc obtained from inverting kohn sham equations. 
+        Equation (3)
+    vxc_lda: np.ndarray
+        LDA potential from forward calculation. 
+    osc_profile: np.ndarray
+        Oscillatory profile that corrects inverted potentials. 
+        Equation (5)
+    """
+    
+    #Make a calculation with LDA.
+    _, correction_wfn = psi4.energy("svwn/"+self.basis_str, return_wfn=True, molecule=self.mol)
+    
+    #Build components on grid:
+    if grid is not None:
+        #Use user-defined grid
+        orb       = self.on_grid_orbitals(Ca=correction_wfn.Ca().np, Cb=correction_wfn.Cb().np, grid=grid)
+        lap       = self.on_grid_lap_phi(Ca=correction_wfn.Ca().np, Cb=correction_wfn.Cb().np, grid=grid)
+        vex, vha  = self.on_grid_esp(Da=correction_wfn.Da().np, Db=correction_wfn.Db().np, grid=grid)[:2]
+        vxc_lda   = self.on_grid_vxc(Da=correction_wfn.Da().np, Db=correction_wfn.Db().np, grid=grid)
+        den       = self.on_grid_density(Da=correction_wfn.Da().np, Db=correction_wfn.Db().np, grid=grid)
+        eig_a = correction_wfn.epsilon_a_subset("AO", "ALL").np
+        eig_b = correction_wfn.epsilon_b_subset("AO", "ALL").np
+        
+    else:
+        #Use DFT grid from LDA calculation
+        vpot = correction_wfn.V_potential()
+        orb       = self.on_grid_orbitals(Ca=correction_wfn.Ca().np, Cb=correction_wfn.Cb().np, vpot=vpot)
+        lap       = self.on_grid_lap_phi(Ca=correction_wfn.Ca().np, Cb=correction_wfn.Cb().np, vpot=vpot)
+        vex, vha  = self.on_grid_esp(Da=correction_wfn.Da().np, Db=correction_wfn.Db().np, vpot=vpot)[:2]
+        vxc_lda   = self.on_grid_vxc(Da=correction_wfn.Da().np, Db=correction_wfn.Db().np, vpot=vpot)
+        den       = self.on_grid_density(Da=correction_wfn.Da().np, Db=correction_wfn.Db().np, vpot=vpot)
+        eig_a = correction_wfn.epsilon_a_subset("AO", "ALL").np
+    
+    #Build Reversed LDA from orbitals and density
+    kinetic = np.zeros_like(den)
+    propios = np.zeros_like(den) 
+
+    #Build v_eff. equation (2) for restricted and unrestricted
+    if self.ref == 1:
+        for i in range(correction_wfn.nalpha()):
+            #Alpha orbitals
+            kinetic += 2.0 * (0.5 * orb[i] * lap[i])
+            propios += 2.0 * eig_a[i] * np.abs(orb[i])**2 
+        
+        with np.errstate(divide='ignore', invalid='ignore'):
+            veff = (kinetic + propios) / den
+        vxc_inverted = veff - vha - vex
+        osc_profile = vxc_inverted - vxc_lda
+        
+    elif self.ref== 2:
+        for i in range(correction_wfn.nalpha()):
+            #Alpha orbitals
+            kinetic[:,0] += (0.5 * orb[i][:,0] * lap[i][:,0])
+            propios[:,0] += eig_a[i] * np.abs(orb[i][:,0])**2 
+        for i in range(correction_wfn.nbeta()):
+            #Beta orbitals
+            kinetic[:,1] += (0.5 * orb[i][:,1] * lap[i][:,1])
+            propios[:,1] += eig_b[i] * np.abs(orb[i][:,1])**2 
+
+        with np.errstate(divide='ignore', invalid='ignore'):
+            veff = (kinetic + propios) / den
+        vxc_inverted = veff - np.repeat(vha[:,None], 2, axis=1) - np.repeat(vex[:,None], 2, axis=1)
+        osc_profile = vxc_inverted - vxc_lda
+
+    return osc_profile

--- a/n2v/grid/grider.py
+++ b/n2v/grid/grider.py
@@ -122,13 +122,14 @@ class Grider(Cubeprop):
 
         return grid, shape
 
-    def generate_dft_grid(self, wfn):
+    def generate_dft_grid(self, vpot):
         """
         Extracts DFT spherical grid and weights from wfn object
 
         Parameters
         ----------
-        wfn: psi4.core.{RKS, UKS}
+        vpot: psi4.core.VBase
+            Vpot object with dft grid data
 
         Returns
         -------
@@ -137,11 +138,6 @@ class Grider(Cubeprop):
             Shape: (4, npoints)
         
         """
-
-        try:
-            vpot = wfn.V_potential()
-        except:
-            raise ValueError("Wfn object does not contain a Vpotential object. Try with one obtained from a DFT calculation")
 
         nblocks = vpot.nblocks()
         blocks = [vpot.get_block(i) for i in range(nblocks)]
@@ -160,7 +156,6 @@ class Grider(Cubeprop):
             dft_grid[3, offset - b_points : offset] = i_block.w().np
 
         return dft_grid
-
 
     #Quantities on Grid
     def on_grid_ao(self, coeff, grid=None, basis=None, vpot=None):
@@ -762,12 +757,6 @@ class Grider(Cubeprop):
         assert i == value.shape[0], "Did not run through all the points. %i %i" %(i, value.shape[0])
         return VFock
 
-
     #Miscellaneous
-    def get_basis_set_correction(self, grid=None):
-        osc_profile = basis_set_correction(self, grid)
-        return osc_profile
-    
-    def invert_kohn_sham_equations(self, wfn, grid=None):
-        vxc_inverted = invert_kohn_sham_equations(self, wfn, grid)
-        return vxc_inverted
+    def get_basis_set_correction(self, grid):
+        return basis_set_correction(self, grid)    

--- a/n2v/methods/direct.py
+++ b/n2v/methods/direct.py
@@ -21,6 +21,8 @@ class Direct():
         grid: np.ndarray. Shape: (3xnpoints)
             Grid used to compute correction. 
             If None, dft grid is used. 
+        correction: bool
+            Adds correction for spurious basis set artifacts
 
         Returns:
         --------

--- a/n2v/methods/direct.py
+++ b/n2v/methods/direct.py
@@ -1,0 +1,110 @@
+"""
+direct.py
+"""
+
+import numpy as np
+np.seterr(divide='ignore', invalid='ignore')
+
+class Direct():
+    def direct_inversion(self, grid, correction=True):
+        """
+        Given a set of canonical kohn-sham orbitals and energies,
+        constructs vxc by inverting the Kohn-Sham Equations.
+        If correction is added, it will be performed according to:
+        Removal of Basis-Set Artifacts in Kohn–Sham Potentials Recovered from Electron Densities
+        Gaiduk + Ryabinkin + Staroverov
+        https://pubs.acs.org/doi/abs/10.1021/ct4004146
+
+        Parameters:
+        -----------
+
+        grid: np.ndarray. Shape: (3xnpoints)
+            Grid used to compute correction. 
+            If None, dft grid is used. 
+
+        Returns:
+        --------
+        vxc_inverted: np.ndarray
+            Vxc obtained from inverting kohn sham equations. 
+            Equation (3)
+        vxc_lda: np.ndarray
+            LDA potential from forward calculation. 
+        osc_profile: np.ndarray
+            Oscillatory profile that corrects inverted potentials. 
+            Equation (5)
+        """
+
+        wfn = self.wfn
+
+        #Sanity check. 
+        try:
+            functional = wfn.functional()
+        except Exception as ex:
+            raise ValueError(f"{ex}. Direct inversion only available for DFT methods. ")
+        if functional.name() == 'HF':
+            raise ValueError(f"Direct inversion only available for DFT methods. ")
+                                    
+        #Build components on grid:
+        if grid is not None:
+            #Use user-defined grid
+            orb       = self.on_grid_orbitals(Ca=wfn.Ca().np, Cb=wfn.Cb().np, grid=grid)
+            lap       = self.on_grid_lap_phi(Ca=wfn.Ca().np, Cb=wfn.Cb().np, grid=grid)
+            vex, vha  = self.on_grid_esp(Da=wfn.Da().np, Db=wfn.Db().np, grid=grid)[:2]
+            den       = self.on_grid_density(Da=wfn.Da().np, Db=wfn.Db().np, grid=grid)
+            eig_a = wfn.epsilon_a_subset("AO", "ALL").np
+            eig_b = wfn.epsilon_b_subset("AO", "ALL").np
+            
+            #Calculate correction
+            if correction is True:
+                osc_profile = self.get_basis_set_correction(grid)
+
+            
+        else:
+            #Use DFT grid
+            vpot = wfn.V_potential()
+            orb       = self.on_grid_orbitals(Ca=wfn.Ca().np, Cb=wfn.Cb().np, vpot=vpot)
+            lap       = self.on_grid_lap_phi(Ca=wfn.Ca().np, Cb=wfn.Cb().np, vpot=vpot)
+            vex, vha  = self.on_grid_esp(Da=wfn.Da().np, Db=wfn.Db().np, vpot=vpot)[:2]
+            den       = self.on_grid_density(Da=wfn.Da().np, Db=wfn.Db().np, vpot=vpot)
+            eig_a = wfn.epsilon_a_subset("AO", "ALL").np
+
+            #Calculate correction
+            if correction is True:
+                dft_grid = self.generate_dft_grid(vpot)
+                osc_profile = self.get_basis_set_correction(dft_grid)
+
+        #Build Reversed LDA from orbitals and density
+        kinetic = np.zeros_like(den)
+        propios = np.zeros_like(den) 
+
+        #Build v_eff. equation (2) for restricted and unrestricted
+        if self.ref == 1:
+            for i in range(wfn.nalpha()):
+                #Alpha orbitals
+                kinetic += 2.0 * (0.5 * orb[i] * lap[i])
+                propios += 2.0 * eig_a[i] * np.abs(orb[i])**2 
+            
+            with np.errstate(divide='ignore', invalid='ignore'):
+                veff = (kinetic + propios) / den
+            vxc_inverted = veff - vha - vex
+            
+        elif self.ref== 2:
+            for i in range(wfn.nalpha()):
+                #Alpha orbitals
+                kinetic[:,0] += (0.5 * orb[i][:,0] * lap[i][:,0])
+                propios[:,0] += eig_a[i] * np.abs(orb[i][:,0])**2 
+            for i in range(wfn.nbeta()):
+                #Beta orbitals
+                kinetic[:,1] += (0.5 * orb[i][:,1] * lap[i][:,1])
+                propios[:,1] += eig_b[i] * np.abs(orb[i][:,1])**2 
+
+            with np.errstate(divide='ignore', invalid='ignore'):
+                veff = (kinetic + propios) / den
+            vxc_inverted = veff - np.repeat(vha[:,None], 2, axis=1) - np.repeat(vex[:,None], 2, axis=1)
+
+        #Add correction
+        if correction is True:
+            vxc_inverted -= osc_profile
+
+        self.grid.vxc = vxc_inverted
+        return vxc_inverted


### PR DESCRIPTION

## Description
PR allows calculating the Basis set Correction described by Staroverov and others:
dx.doi.org/10.1021/ct4004146

## Todos
  - [x] Addition of functions that calculate Gradient/Laplacian of Molecular Orbitals on the grid. 
  - [x] Fixed some typos and homogenized returns of grid components:
          For a restricted calculation, some functions would return a (npoints,1) and some others would return (npoints, ). 
          I stuck with the latter since the former can introduce errors that cause confusion when multiplied/divided by vectors. 
  - [x] Removed `on_grid_all()` due to lack of practical use. 
  - [x] Addition of two functions associated with the method:
      1. `invert_kohn_sham_quations()`
      2. `basis_set_corrections()`
     
      Both functions have the same structure, the latter just forcing an LDA calculation. The original paper suggests using LDA_X only, but it is a method that currently Psi4 does not have. Tried locally with both LDA_X and LDA_x+LDA_c and both work in the same way.
     The function is sensitive to restricted and unrestricted calculations, but the correction is the same for alpha/beta components of vxc. 

## Questions
- [x] Should new functions `i)` `ii)` remain the same or combined into one with an additional argument that enforces LDA calculation?
- [ ] Should we remove the option for unrestricted calculation and return a single array whether it is a restricted or unrestricted calculation?
 

## Status
- [x] Ready to go