### PR TITLE
Bugfix

### DIFF
--- a/n2v/grid/basis_set_artifact_correction.py
+++ b/n2v/grid/basis_set_artifact_correction.py
@@ -51,11 +51,11 @@ def invert_kohn_sham_equations(self, wfn, grid):
         
     else:
         #Use DFT grid
-        vpot = wfn.V_potential()
-        orb       = self.on_grid_orbitals(Ca=wfn.Ca().np, Cb=wfn.Cb().np, vpot=vpot)
-        lap       = self.on_grid_lap_phi(Ca=wfn.Ca().np, Cb=wfn.Cb().np, vpot=vpot)
-        vex, vha  = self.on_grid_esp(Da=wfn.Da().np, Db=wfn.Db().np, vpot=vpot)[:2]
-        den       = self.on_grid_density(Da=wfn.Da().np, Db=wfn.Db().np, vpot=vpot)
+        Vpot = wfn.V_potential()
+        orb       = self.on_grid_orbitals(Ca=wfn.Ca().np, Cb=wfn.Cb().np, Vpot=Vpot)
+        lap       = self.on_grid_lap_phi(Ca=wfn.Ca().np, Cb=wfn.Cb().np, Vpot=Vpot)
+        vex, vha  = self.on_grid_esp(Da=wfn.Da().np, Db=wfn.Db().np, Vpot=Vpot)[:2]
+        den       = self.on_grid_density(Da=wfn.Da().np, Db=wfn.Db().np, Vpot=Vpot)
         eig_a = wfn.epsilon_a_subset("AO", "ALL").np
 
     #Build Reversed LDA from orbitals and density
@@ -130,12 +130,12 @@ def basis_set_correction(self, grid):
         
     else:
         #Use DFT grid from LDA calculation
-        vpot = correction_wfn.V_potential()
-        orb       = self.on_grid_orbitals(Ca=correction_wfn.Ca().np, Cb=correction_wfn.Cb().np, vpot=vpot)
-        lap       = self.on_grid_lap_phi(Ca=correction_wfn.Ca().np, Cb=correction_wfn.Cb().np, vpot=vpot)
-        vex, vha  = self.on_grid_esp(Da=correction_wfn.Da().np, Db=correction_wfn.Db().np, vpot=vpot)[:2]
-        vxc_lda   = self.on_grid_vxc(Da=correction_wfn.Da().np, Db=correction_wfn.Db().np, vpot=vpot)
-        den       = self.on_grid_density(Da=correction_wfn.Da().np, Db=correction_wfn.Db().np, vpot=vpot)
+        Vpot = correction_wfn.V_potential()
+        orb       = self.on_grid_orbitals(Ca=correction_wfn.Ca().np, Cb=correction_wfn.Cb().np, Vpot=Vpot)
+        lap       = self.on_grid_lap_phi(Ca=correction_wfn.Ca().np, Cb=correction_wfn.Cb().np, Vpot=Vpot)
+        vex, vha  = self.on_grid_esp(Da=correction_wfn.Da().np, Db=correction_wfn.Db().np, Vpot=Vpot)[:2]
+        vxc_lda   = self.on_grid_vxc(Da=correction_wfn.Da().np, Db=correction_wfn.Db().np, Vpot=Vpot)
+        den       = self.on_grid_density(Da=correction_wfn.Da().np, Db=correction_wfn.Db().np, Vpot=Vpot)
         eig_a = correction_wfn.epsilon_a_subset("AO", "ALL").np
     
     #Build Reversed LDA from orbitals and density

--- a/n2v/methods/direct.py
+++ b/n2v/methods/direct.py
@@ -63,16 +63,16 @@ class Direct():
             
         else:
             #Use DFT grid
-            vpot = wfn.V_potential()
-            orb       = self.on_grid_orbitals(Ca=wfn.Ca().np, Cb=wfn.Cb().np, vpot=vpot)
-            lap       = self.on_grid_lap_phi(Ca=wfn.Ca().np, Cb=wfn.Cb().np, vpot=vpot)
-            vex, vha  = self.on_grid_esp(Da=wfn.Da().np, Db=wfn.Db().np, vpot=vpot)[:2]
-            den       = self.on_grid_density(Da=wfn.Da().np, Db=wfn.Db().np, vpot=vpot)
+            Vpot = wfn.V_potential()
+            orb       = self.on_grid_orbitals(Ca=wfn.Ca().np, Cb=wfn.Cb().np, Vpot=Vpot)
+            lap       = self.on_grid_lap_phi(Ca=wfn.Ca().np, Cb=wfn.Cb().np, Vpot=Vpot)
+            vex, vha  = self.on_grid_esp(Da=wfn.Da().np, Db=wfn.Db().np, Vpot=Vpot)[:2]
+            den       = self.on_grid_density(Da=wfn.Da().np, Db=wfn.Db().np, Vpot=Vpot)
             eig_a = wfn.epsilon_a_subset("AO", "ALL").np
 
             #Calculate correction
             if correction is True:
-                dft_grid = self.generate_dft_grid(vpot)
+                dft_grid = self.generate_dft_grid(Vpot)
                 osc_profile = self.get_basis_set_correction(dft_grid)
 
         #Build Reversed LDA from orbitals and density

--- a/n2v/methods/mrks.py
+++ b/n2v/methods/mrks.py
@@ -509,7 +509,7 @@ class MRKS():
             self._diagonalize_with_potential_vFock(v=vxc_Fock)
 
             print(f"Iter: {mRKS_step}, Density Change: {Derror:2.2e}, Eigenvalue Change: {eerror:2.2e}, "
-                  "Potential Change: {verror:2.2e}.")
+                  f"Potential Change: {verror:2.2e}.")
 
         if vxc_grid is not None:
             grid_info = self.grid_to_blocks(vxc_grid)

--- a/n2v/methods/oucarter.py
+++ b/n2v/methods/oucarter.py
@@ -112,7 +112,7 @@ class OC():
         epsilon_b_LDA = wfn_LDA.epsilon_b().np
         self.Vpot = wfn_LDA.V_potential()
 
-        vxc_LDA_DFT = self.on_grid_vxc(Da=Da_LDA, Db=Db_LDA, vpot=self.Vpot)
+        vxc_LDA_DFT = self.on_grid_vxc(Da=Da_LDA, Db=Db_LDA, Vpot=self.Vpot)
         vxc_LDA = self.on_grid_vxc(Da=Da_LDA, Db=Db_LDA, grid=grid_info)
         if self.ref != 1:
             assert vxc_LDA.shape[-1] == 2
@@ -269,7 +269,7 @@ class OC():
             self.eigvecs_b = np.array(wfn_temp.epsilon_b())
             del wfn_temp
 
-        # nerror = self.on_grid_density(Da=self.nt[0]-self.Da, Db=self.nt[1]-self.Da, vpot=self.Vpot)
+        # nerror = self.on_grid_density(Da=self.nt[0]-self.Da, Db=self.nt[1]-self.Da, Vpot=self.Vpot)
         # w = self.Vpot.get_np_xyzw()[-1]
         # nerror = np.sum(np.abs(nerror.T) * w)
         # print("nerror", nerror)
@@ -332,7 +332,7 @@ class OC():
 
 
             print(f"Iter: {OC_step}, Density Change: {Derror:2.2e}, Eigenvalue Change: {eerror:2.2e}.")
-            # nerror = self.on_grid_density(Da=self.nt[0] - self.Da, Db=self.nt[1] - self.Da, vpot=self.Vpot)
+            # nerror = self.on_grid_density(Da=self.nt[0] - self.Da, Db=self.nt[1] - self.Da, Vpot=self.Vpot)
             # nerror = np.sum(np.abs(nerror.T) * w)
             # print("nerror", nerror)
 

--- a/n2v/methods/pdeco.py
+++ b/n2v/methods/pdeco.py
@@ -80,6 +80,9 @@ class PDECO():
         """
         if wfn is None:
             wfn = self.wfn
+
+        print(f"4-AO-Overlap tensor will take about {self.nbf **4 / 8 * 1e-9:d} GB.")
+
         mints = psi4_mintshelper( self.basis )
 
         aux_basis = psi4_basiset.build(wfn.molecule(), "DF_BASIS_SCF", "",

--- a/n2v/methods/zmp.py
+++ b/n2v/methods/zmp.py
@@ -89,12 +89,12 @@ class ZMP():
             functional = psi4.driver.dft.build_superfunctional("SVWN", restricted=True if self.ref==1 else False)[0]
             Vpot = psi4.core.VBase.build(self.basis, functional, ref)
             Vpot.initialize()
-            self.vpot = Vpot
+            self.Vpot = Vpot
         else:
-            self.vpot = self.wfn.V_potential()
+            self.Vpot = self.wfn.V_potential()
 
         # Obtain target density on dft_grid 
-        D0 = self.on_grid_density(grid=None, Da=self.nt[0], Db=self.nt[1],  vpot=self.vpot)
+        D0 = self.on_grid_density(grid=None, Da=self.nt[0], Db=self.nt[1],  Vpot=self.Vpot)
 
         #Calculate kernels
         if zmp_functional.lower() != 'hartree':
@@ -109,9 +109,9 @@ class ZMP():
             elif zmp_functional == 'exp':
                 Sa0 = Da0 ** 0.05
                 Sb0 = Db0 ** 0.05
-            self.Sa0 = self.dft_grid_to_fock(Sa0, Vpot=self.vpot)
+            self.Sa0 = self.dft_grid_to_fock(Sa0, Vpot=self.Vpot)
             if self.ref == 2:
-                self.Sb0 = self.dft_grid_to_fock(Sb0, Vpot=self.vpot)
+                self.Sb0 = self.dft_grid_to_fock(Sb0, Vpot=self.Vpot)
             else: 
                 self.Sb0 = self.Sa0.copy()
 
@@ -256,7 +256,7 @@ class ZMP():
                 if SCF_ITER == maxiter - 1:
                     raise ValueError("ZMP Error: Maximum Number of SCF cycles reached. Try different settings.")
 
-            density_current = self.on_grid_density(grid=None, Da=Da, Db=Db, vpot=self.vpot)
+            density_current = self.on_grid_density(grid=None, Da=Da, Db=Db, Vpot=self.Vpot)
             grid_diff = np.max(np.abs(D0 - density_current))
             if np.abs(grid_diff_old) < np.abs(grid_diff):
                 print(f"\nZMP halted. Density Error Stops Updating: old: {grid_diff_old}, current: {grid_diff}.")
@@ -331,7 +331,7 @@ class ZMP():
 
         else:
 
-            D = self.on_grid_density(vpot=self.vpot, Da=Da, Db=Db)
+            D = self.on_grid_density(Vpot=self.Vpot, Da=Da, Db=Db)
 
             if self.ref == 1:
                 Da, Db = D[:,0], D[:,0]
@@ -348,8 +348,8 @@ class ZMP():
                 Sb = Db ** 0.05
 
             #Generate AO matrix from functions. 
-            Sa = self.dft_grid_to_fock(Sa, Vpot=self.vpot)
-            Sb = self.dft_grid_to_fock(Sb, Vpot=self.vpot)
+            Sa = self.dft_grid_to_fock(Sa, Vpot=self.Vpot)
+            Sb = self.dft_grid_to_fock(Sb, Vpot=self.Vpot)
             vc = (Sa + Sb) - (self.Sa0 + self.Sb0)
 
         return vc


### PR DESCRIPTION
## Description
The reason for np.empty to np.zeros is that blocks that are far way from the AO will be skipped and thus the default should be zero.
Change vpot to Vpot for consistency.
Fixed a bug in on_grid_density (self.Da to self.nt[0])
Fixed a print bug in mrks.py

## Todos
Notable points that this PR has either accomplished or will accomplish.
  - [ ] TODO 1

## Questions
- [ ] Question1

## Status
- [ ] Ready to go